### PR TITLE
Support KeyPaths with multiple return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let ex = Example()
 
 // Set up the publishers
 let c1 = ex.$progress.sink { print("\($0.fractionCompleted) completed") }
-let c1 = ex.$textualRepresentation.sink { print("\($0)") }
+let c2 = ex.$textualRepresentation.sink { print("\($0)") }
 
 // Interact with the class as usual
 ex.progress.completedUnitCount += 1

--- a/Sources/PublishedKVO/PublishedKVO.swift
+++ b/Sources/PublishedKVO/PublishedKVO.swift
@@ -91,8 +91,8 @@ public class PublishedKVO<Value: NSObject>: NSObject {
 	/// - parameter keyPaths: An array of `KeyPath`s to use with Key-Value-Observing.
 	public init(wrappedValue value: Value, _ keyPaths: [PartialKeyPath<Value>]) {
 		self.subject = CurrentValueSubject<Value, Never>(value)
-		self.keyPaths = keyPaths.map {
-			guard let str = $0._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \($0)") }
+		self.keyPaths = keyPaths.map { keyPath in
+			guard let str = keyPath._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \(keyPath)") }
 			return str
 		}
 		

--- a/Sources/PublishedKVO/PublishedKVO.swift
+++ b/Sources/PublishedKVO/PublishedKVO.swift
@@ -85,16 +85,16 @@ $progress3 incomming 0.4 actual 0.2
 @propertyWrapper
 public class PublishedKVO<Value: NSObject>: NSObject {
 	private let subject: CurrentValueSubject<Value, Never>
-	private let keyPaths: [String]
+	private let keyPaths: Set<String>
 	
 	/// The initializer accepting multiple keyPath's to watch for changes.
-	/// - parameter keyPaths: An array of `KeyPath`s to use with Key-Value-Observing.
-	public init(wrappedValue value: Value, _ keyPaths: [PartialKeyPath<Value>]) {
+	/// - parameter keyPaths: A set of `KeyPath`s to use with Key-Value-Observing.
+	public init(wrappedValue value: Value, _ keyPaths: Set<PartialKeyPath<Value>>) {
 		self.subject = CurrentValueSubject<Value, Never>(value)
-		self.keyPaths = keyPaths.map { keyPath in
+		self.keyPaths = Set(keyPaths.lazy.map { keyPath in
 			guard let str = keyPath._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \(keyPath)") }
 			return str
-		}
+		})
 		
 		super.init()
 		setupKVO()

--- a/Sources/PublishedKVO/PublishedKVO.swift
+++ b/Sources/PublishedKVO/PublishedKVO.swift
@@ -91,7 +91,10 @@ public class PublishedKVO<Value: NSObject>: NSObject {
 	/// - parameter keyPaths: An array of `KeyPath`s to use with Key-Value-Observing.
 	public init(wrappedValue value: Value, _ keyPaths: [PartialKeyPath<Value>]) {
 		self.subject = CurrentValueSubject<Value, Never>(value)
-		self.keyPaths = keyPaths.map { $0._kvcKeyPathString! }
+		self.keyPaths = keyPaths.map {
+			guard let str = $0._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \($0)") }
+			return str
+		}
 		
 		super.init()
 		setupKVO()


### PR DESCRIPTION
Hello.
I’m planning to use this in my project, but I’m stumbling on some things.

When using multiple `KeyPath`s, you cannot specify `KeyPath`s with different return types at the same time, because generic types of the `KeyPath` array is inferred and limited to one type.

```swift
@PublishedKVO([\.isIndeterminate, \.fractionCompleted]) // <- Bool, Double
var progress = Progress()
```

So to make it more flexible, I changed the argument of the function to a set of `PartialKeyPath<Value>` (type-ereasing).
The return type isn’t that important since it’s only for detecting value changes.

Also there was an issue where the event wouldn’t fire when the SwiftUI view was updated and the `wrappedValue` changed, so I made it to rehook when the setter was called.